### PR TITLE
Update to nom v8 and nom-derive v0.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
     - name: Build tropic01
@@ -27,3 +26,16 @@ jobs:
     - name: Run tests
       run: cargo test
 
+  build-no-std:
+    runs-on: ubuntu-latest
+    env:
+      CARGO_BUILD_TARGET: thumbv8m.main-none-eabi
+    steps:
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+    - name: Install ${{ env.CARGO_BUILD_TARGET }} target
+      run: rustup target add ${CARGO_BUILD_TARGET}
+    - name: Build tropic01
+      run: |
+        cargo build --package tropic01 --no-default-features
+        cargo build --package tropic01
+        cargo build --package tropic01 --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,3 +139,6 @@ zero_sized_map_values = "warn"
 # missing_crate_level_docs = "warn"
 broken_intra_doc_links = "warn"
 private_doc_tests = "warn"
+
+[patch.crates-io]
+nom-derive = { git = "https://github.com/rust-bakery/nom-derive.git", rev = "f68f464f50f7162483355e61a50ec2a7dae8044f" }

--- a/tropic01/Cargo.toml
+++ b/tropic01/Cargo.toml
@@ -25,8 +25,8 @@ derive_more = { version = "2", default-features = false, features = [
 dummy-pin = { version = "1.0.0", default-features = false }
 embedded-hal = { version = "1", default-features = false }
 hmac = { version = "0.12", default-features = false }
-nom = { version = "7.1.3", default-features = false }
-nom-derive = { version = "0.10.1", default-features = false }
+nom = { version = "8", default-features = false }
+nom-derive = { version = "0.11", default-features = false }
 packed_struct = { version = "0.10.1", default-features = false }
 sha2 = { version = "0.10", default-features = false }
 x25519-dalek = { version = "2", default-features = false, features = [


### PR DESCRIPTION
This patch updates to nom v8 and the unreleased nom-derive v0.11 to work around the no-std incompatibility (https://github.com/tropicsquare/libtropic-rs/issues/7).